### PR TITLE
Add bulk competitor controls to brand monitor

### DIFF
--- a/components/brand-monitor/company-card.tsx
+++ b/components/brand-monitor/company-card.tsx
@@ -25,6 +25,7 @@ interface CompanyCardProps {
   }>;
   onRemoveCompetitor?: (index: number) => void;
   onAddCompetitor?: () => void;
+  onClearCompetitors?: () => void;
   onContinueToAnalysis?: () => void;
 }
 
@@ -36,7 +37,8 @@ export function CompanyCard({
   identifiedCompetitors = [],
   onRemoveCompetitor,
   onAddCompetitor,
-  onContinueToAnalysis 
+  onClearCompetitors,
+  onContinueToAnalysis
 }: CompanyCardProps) {
   const [logoError, setLogoError] = React.useState(false);
   const [faviconError, setFaviconError] = React.useState(false);
@@ -163,11 +165,19 @@ export function CompanyCard({
       {showCompetitors && identifiedCompetitors.length > 0 && (
         <div className="border-t border-gray-200">
           <div className="px-8 py-6">
-            <div className="mb-4">
+            <div className="mb-4 flex items-center justify-between">
               <div>
                 <h3 className="text-sm font-medium text-gray-900">Competitors</h3>
                 <p className="text-sm text-gray-500">We'll compare {company.name} against these {identifiedCompetitors.length} competitors</p>
               </div>
+              {onClearCompetitors && (
+                <button
+                  onClick={onClearCompetitors}
+                  className="text-sm text-red-600 hover:underline"
+                >
+                  Clear all
+                </button>
+              )}
             </div>
               
               <div className="grid grid-cols-3 gap-4">

--- a/components/brand-monitor/modals/add-competitor-modal.tsx
+++ b/components/brand-monitor/modals/add-competitor-modal.tsx
@@ -1,74 +1,94 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
+
+interface CompetitorEntry {
+  name: string;
+  url: string;
+}
 
 interface AddCompetitorModalProps {
   isOpen: boolean;
-  competitorName: string;
-  competitorUrl: string;
-  onNameChange: (name: string) => void;
-  onUrlChange: (url: string) => void;
-  onAdd: () => void;
+  onAdd: (competitors: CompetitorEntry[]) => void;
   onClose: () => void;
 }
 
 export function AddCompetitorModal({
   isOpen,
-  competitorName,
-  competitorUrl,
-  onNameChange,
-  onUrlChange,
   onAdd,
   onClose
 }: AddCompetitorModalProps) {
+  const [competitors, setCompetitors] = useState<CompetitorEntry[]>(
+    Array.from({ length: 5 }, () => ({ name: '', url: '' }))
+  );
+
   if (!isOpen) return null;
-  
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && competitorName.trim()) {
-      e.preventDefault();
-      onAdd();
+
+  const handleChange = (
+    index: number,
+    field: 'name' | 'url',
+    value: string
+  ) => {
+    setCompetitors((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const handleAdd = () => {
+    const validCompetitors = competitors
+      .filter((c) => c.name.trim())
+      .map((c) => ({ name: c.name.trim(), url: c.url.trim() }));
+    if (validCompetitors.length > 0) {
+      onAdd(validCompetitors);
     }
   };
-  
+
+  const canAdd = competitors.some((c) => c.name.trim());
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-fade-in">
-      <div className="bg-white rounded-xl shadow-xl max-w-lg w-full mx-4 animate-fade-in">
+      <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full mx-4 animate-fade-in">
         <div className="p-6">
-          <h3 className="text-lg font-semibold mb-4">Add Competitor</h3>
+          <h3 className="text-lg font-semibold mb-4">Add Competitors</h3>
           <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Competitor Name
-              </label>
-              <input
-                type="text"
-                value={competitorName}
-                onChange={(e) => onNameChange(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="e.g., Anthropic"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                autoFocus
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Website URL (optional)
-              </label>
-              <input
-                type="text"
-                value={competitorUrl}
-                onChange={(e) => onUrlChange(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="e.g., anthropic.com"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-            </div>
+            {competitors.map((comp, idx) => (
+              <div key={idx} className="flex gap-4">
+                <div className="flex-1">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Competitor Name {idx + 1}
+                  </label>
+                  <input
+                    type="text"
+                    value={comp.name}
+                    onChange={(e) => handleChange(idx, 'name', e.target.value)}
+                    placeholder="e.g., Anthropic"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Website URL (optional)
+                  </label>
+                  <input
+                    type="text"
+                    value={comp.url}
+                    onChange={(e) => handleChange(idx, 'url', e.target.value)}
+                    placeholder="e.g., anthropic.com"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                  />
+                </div>
+              </div>
+            ))}
           </div>
           <div className="flex gap-3 mt-6">
             <button
-              onClick={onAdd}
-              disabled={!competitorName.trim()}
+              onClick={handleAdd}
+              disabled={!canAdd}
               className="flex-1 h-10 px-4 rounded-[10px] text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 bg-orange-500 text-white hover:bg-orange-300 dark:bg-orange-500 dark:hover:bg-orange-300 dark:text-white [box-shadow:inset_0px_-2.108433723449707px_0px_0px_#c2410c,_0px_1.2048193216323853px_6.325301647186279px_0px_rgba(234,_88,_12,_58%)] hover:translate-y-[1px] hover:scale-[0.98] hover:[box-shadow:inset_0px_-1px_0px_0px_#c2410c,_0px_1px_3px_0px_rgba(234,_88,_12,_40%)] active:translate-y-[2px] active:scale-[0.97] active:[box-shadow:inset_0px_1px_1px_0px_#c2410c,_0px_1px_2px_0px_rgba(234,_88,_12,_30%)] disabled:shadow-none disabled:hover:translate-y-0 disabled:hover:scale-100"
             >
-              Add Competitor
+              Add Competitors
             </button>
             <button
               onClick={onClose}
@@ -82,3 +102,4 @@ export function AddCompetitorModal({
     </div>
   );
 }
+

--- a/lib/brand-monitor-reducer.ts
+++ b/lib/brand-monitor-reducer.ts
@@ -20,6 +20,7 @@ export type BrandMonitorAction =
   | { type: 'SET_IDENTIFIED_COMPETITORS'; payload: IdentifiedCompetitor[] }
   | { type: 'REMOVE_COMPETITOR'; payload: number }
   | { type: 'ADD_COMPETITOR'; payload: IdentifiedCompetitor }
+  | { type: 'CLEAR_COMPETITORS' }
   | { type: 'UPDATE_COMPETITOR_METADATA'; payload: { index: number; metadata: CompetitorMetadata } }
   | { type: 'SET_ANALYSIS_PROGRESS'; payload: AnalysisProgressState }
   | { type: 'UPDATE_ANALYSIS_PROGRESS'; payload: Partial<AnalysisProgressState> }
@@ -33,7 +34,6 @@ export type BrandMonitorAction =
   | { type: 'SET_EXPANDED_PROMPT_INDEX'; payload: number | null }
   | { type: 'TOGGLE_MODAL'; payload: { modal: 'addPrompt' | 'addCompetitor'; show: boolean } }
   | { type: 'SET_NEW_PROMPT_TEXT'; payload: string }
-  | { type: 'SET_NEW_COMPETITOR'; payload: { name?: string; url?: string } }
   | { type: 'RESET_STATE' }
   | { type: 'SCRAPE_SUCCESS'; payload: Company }
   | { type: 'ANALYSIS_COMPLETE'; payload: Analysis };
@@ -153,8 +153,6 @@ export interface BrandMonitorState {
   showAddPromptModal: boolean;
   showAddCompetitorModal: boolean;
   newPromptText: string;
-  newCompetitorName: string;
-  newCompetitorUrl: string;
 }
 
 // Initial State
@@ -193,9 +191,7 @@ export const initialBrandMonitorState: BrandMonitorState = {
   currentPeriod: true,
   showAddPromptModal: false,
   showAddCompetitorModal: false,
-  newPromptText: '',
-  newCompetitorName: '',
-  newCompetitorUrl: ''
+  newPromptText: ''
 };
 
 // Reducer
@@ -259,9 +255,15 @@ export function brandMonitorReducer(
       };
       
     case 'ADD_COMPETITOR':
-      return { 
-        ...state, 
-        identifiedCompetitors: [...state.identifiedCompetitors, action.payload] 
+      return {
+        ...state,
+        identifiedCompetitors: [...state.identifiedCompetitors, action.payload]
+      };
+
+    case 'CLEAR_COMPETITORS':
+      return {
+        ...state,
+        identifiedCompetitors: []
       };
       
     case 'UPDATE_COMPETITOR_METADATA':
@@ -333,13 +335,6 @@ export function brandMonitorReducer(
       
     case 'SET_NEW_PROMPT_TEXT':
       return { ...state, newPromptText: action.payload };
-      
-    case 'SET_NEW_COMPETITOR':
-      return {
-        ...state,
-        ...(action.payload.name !== undefined && { newCompetitorName: action.payload.name }),
-        ...(action.payload.url !== undefined && { newCompetitorUrl: action.payload.url })
-      };
       
     case 'RESET_STATE':
       return initialBrandMonitorState;


### PR DESCRIPTION
## Summary
- add reducer action and UI support to clear all suggested competitors
- allow adding up to five competitors at once in modal
- wire new clear and bulk-add flows into brand monitor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bc270661f4832c892b27452b3e3d87